### PR TITLE
Add ROS Position Control via Topic Subscription

### DIFF
--- a/arduino_control/control_as_client/a_declarations.ino
+++ b/arduino_control/control_as_client/a_declarations.ino
@@ -22,6 +22,7 @@ bool get_fork_state();
 void set_remote_indicator();
 
 // ROS & Network Interfaces
+void cb_joint_command(const std_msgs::Float64);
 void update_ros_robot_status();
 void update_ros_joint_states();
 void clearSerialBuffer();

--- a/arduino_control/control_as_client/a_declarations.ino
+++ b/arduino_control/control_as_client/a_declarations.ino
@@ -10,6 +10,8 @@ void setup_ros();
 // Motion
 void moveDown();
 void moveUp();
+void set_flow_control_valve(bool state);
+bool tempFlowValveState = false;
 void halt();
 
 // Feedback

--- a/arduino_control/control_as_client/b_configure.ino
+++ b/arduino_control/control_as_client/b_configure.ino
@@ -33,6 +33,9 @@ const float minStrokeSoft = 0.0;
 const float maxStrokeHard = 0.20294907837554;   // not currently used by control
 const float minStrokeHard = 0.0;                // not currently used by control
 
+//Position control
+const float motionBuffer = 0.012;
+
 //Target Position
 bool remoteMotionEnabled = false;
 bool directionOfMotion;                  // false = down, true = up

--- a/arduino_control/control_as_client/b_configure.ino
+++ b/arduino_control/control_as_client/b_configure.ino
@@ -33,6 +33,10 @@ const float minStrokeSoft = 0.0;
 const float maxStrokeHard = 0.20294907837554;   // not currently used by control
 const float minStrokeHard = 0.0;                // not currently used by control
 
+//Remote Interface
+bool ros_enabled = false;
+float last_ros_joint_command = 0;        // Initialize goal to zero for safety
+
 //Position control
 const float motionBuffer = 0.012;
 

--- a/arduino_control/control_as_client/c_setup.ino
+++ b/arduino_control/control_as_client/c_setup.ino
@@ -11,12 +11,14 @@ std_msgs::Header robot_status_header;
 
 sensor_msgs::JointState joint_state_msg;
 std_msgs::Bool fork_state_msg;
+std_msgs::Float64 joint_command;
 //industrial_msgs::RobotStatus robot_status_msg;
 
 ros::Publisher pub_joint_states("joint_states", &joint_state_msg);
 ros::Publisher pub_fork_state("fork_state", &fork_state_msg);
 //ros::Publisher pub_robot_status("robot_status", &robot_status_msg);
 
+ros::Subscriber<std_msgs::Float64> sub_joint_command("joint_command", cb_joint_command);
 
 
 // -------------------
@@ -38,6 +40,10 @@ void setup() {
     Serial.println("Setup Configuration: Network enabled. Will now attempt to connect to network");
     Ethernet.begin(mac);
     setup_network();
+    ros_enabled = true;
+  }
+  else {
+    ros_enabled = false;
   }
 
   // Setup ROS handles

--- a/arduino_control/control_as_client/control_as_client.ino
+++ b/arduino_control/control_as_client/control_as_client.ino
@@ -33,6 +33,7 @@
 #include <std_msgs/Header.h>
 #include <sensor_msgs/JointState.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Float64.h>
 //#include <industrial_msgs/RobotStatus.h>
 
 

--- a/arduino_control/control_as_client/e_motion.ino
+++ b/arduino_control/control_as_client/e_motion.ino
@@ -15,6 +15,15 @@ void moveUp() {
 }
 
 
+void set_flow_control_valve(bool state)
+{
+  //Input 'state' sets the speed of the press
+  //by opening/closing the flow control valve.
+  //High for fast, LOW for slow
+  P1.writeDiscrete(state,1,7); //Set the flow control valve to state
+}
+
+
 void halt() {
   P1.writeDiscrete(LOW,1,2);   //Turn slot 1 channel 1 off
   P1.writeDiscrete(LOW,1,3);   //Turn slot 1 channel 2 off

--- a/arduino_control/control_as_client/g_ros.ino
+++ b/arduino_control/control_as_client/g_ros.ino
@@ -13,6 +13,32 @@ void setup_ros() {
   nh.advertise(pub_fork_state);
 //  nh.advertise(pub_robot_status);/
 
+  nh.subscribe(sub_joint_command);
+}
+
+void cb_joint_command(const std_msgs::Float64& msg) {
+  
+  // Extract data from message
+  last_ros_joint_command = msg.data;
+
+  // Lookup Current Position
+  float current_posn = posn_incr2meter(P1.readAnalog(2, 1));
+
+  // Soft Stop Limits
+  if      (last_ros_joint_command > maxStrokeSoft) last_ros_joint_command = maxStrokeSoft;
+  else if (last_ros_joint_command < minStrokeSoft) last_ros_joint_command = minStrokeSoft;
+
+  // Set the direction of motion
+  if (current_posn < last_ros_joint_command) directionOfMotion = false;  // down
+  else                                       directionOfMotion = true;   // up
+
+  // Serial Feedback
+  Serial.print("Set New Target Position: ");
+  Serial.println(last_ros_joint_command, 3);
+
+  // Enable Motion
+  remoteMotionEnabled = true;
+  remoteTargetAchieved = false;
 }
 
 

--- a/arduino_control/control_as_client/h_controller.ino
+++ b/arduino_control/control_as_client/h_controller.ino
@@ -83,10 +83,26 @@ void controller(float current_posn) {
     // Actuate if target not met
     if (remoteTargetAchieved == true) {
       halt();
+      set_flow_control_valve(LOW);  // default back to slow speed
       target_posn = current_posn;   // fail safe
     }
     else if (directionOfMotion == false)   moveDown();
     else if (directionOfMotion == true)    moveUp();
     
+    // Set speed of press motion
+    if(directionOfMotion == false && current_posn > target_posn - motionBuffer) // moving down
+    {
+      set_flow_control_valve(LOW);
+    }
+    else 
+    {
+      set_flow_control_valve(HIGH);
+    }
+
+    if(directionOfMotion == true && remoteTargetAchieved == false) // moving up
+    {
+      set_flow_control_valve(HIGH);
+    }
+    else if (directionOfMotion == true) set_flow_control_valve(LOW);
   }
 }

--- a/arduino_control/control_as_client/h_controller.ino
+++ b/arduino_control/control_as_client/h_controller.ino
@@ -37,7 +37,12 @@ void controller(float current_posn) {
   // Remote Input ~ Serial or ROS
   // -----------------------------
 
-  if (Serial.available() && override_lockout == false) {
+  if (Serial.available() && override_lockout == true) {
+    Serial.println("--- !! Remote Control Lockout. Please wait 5-seconds !! ---");
+    clearSerialBuffer();
+  }
+  
+  else if (Serial.available() && ros_enabled == false && override_lockout == false) {
     
     // Serial Client Input Position of unit: [mm]
     target_posn = Serial.parseFloat() * 0.001;
@@ -59,14 +64,16 @@ void controller(float current_posn) {
     remoteMotionEnabled = true;
     remoteTargetAchieved = false;
   }
-  else if (Serial.available() && override_lockout == true) {
-    Serial.println("--- !! Remote Control Lockout. Please wait 5-seconds !! ---");
-    clearSerialBuffer();
+
+  else if (ros_enabled == true && override_lockout == false) {
+    // Serial Client Input Position of unit: [meter]
+    target_posn = last_ros_joint_command;
   }
 
-  //else if (_ADD_ROS_CHECK_) {
-  //  //ADD ROS CODE HERE
-  //}
+  if (Serial.available() && ros_enabled == true) {
+    Serial.println("--- !! Serial Control Lockout. Only accepting ROS Control. !! ---");
+    clearSerialBuffer();
+  }
 
 
 
@@ -80,7 +87,7 @@ void controller(float current_posn) {
     if      (directionOfMotion == false && current_posn >= target_posn) remoteTargetAchieved = true;  // overshoot moving down              
     else if (directionOfMotion == true  && current_posn <= target_posn) remoteTargetAchieved = true;  // overshoot moving up
     
-    // Actuate if target not met
+    // Actuate Control given Target Achieved
     if (remoteTargetAchieved == true) {
       halt();
       set_flow_control_valve(LOW);  // default back to slow speed

--- a/arduino_control/control_as_client/h_controller.ino
+++ b/arduino_control/control_as_client/h_controller.ino
@@ -15,7 +15,9 @@ void controller(float current_posn) {
   bool override_lockout = (last_override + override_timeout) > millis();
 
   if (mswitch_up || mswitch_dwn || override_lockout) {
+    set_flow_control_valve(LOW);
     set_remote_indicator(false);
+    remoteMotionEnabled = false;
     if ( mswitch_up == true && mswitch_dwn == false ) {
       last_override = millis();
       moveUp();
@@ -25,9 +27,8 @@ void controller(float current_posn) {
       moveDown();
     }
     else {
-      remoteMotionEnabled = false;
-      target_posn = current_posn; // Ensure fail's safe
       halt();
+      target_posn = current_posn; // Ensure fail's safe
     } 
   }
 

--- a/arduino_control/control_as_client/i_run.ino
+++ b/arduino_control/control_as_client/i_run.ino
@@ -15,7 +15,7 @@ void loop()
   report_serial_position();
   
   // ROS Interface
-  if (nh.connected()) {
+  if (nh.connected() && ros_enabled) {
 
     // Set ROS Indicator Light = ON
     set_remote_indicator(true);

--- a/launch/connect_arduino.launch
+++ b/launch/connect_arduino.launch
@@ -1,4 +1,4 @@
 <launch>
 	<!-- Default Port: 11411 -->
-	<node pkg="rosserial_server" type="socket_node" name="rosserial_server" output="screen" />
+	<node pkg="rosserial_server" type="socket_node" name="control_interface" ns="coaliron" output="screen" />
 </launch>


### PR DESCRIPTION
Add ROS Position Control via Topic Subscription. If the ethernet card is connected, the PLC will attempt to connect to a server at the defined ROS Master address. This server is started using this packages provided launch file.

Redefines the node name and namespace to better reflect role as an hardware interface.

## Testing
:heavy_check_mark: Verified Serial lockout when Remote Mode set to ROS
:heavy_check_mark: Verified NIC does not attempt to connect when Remote Mode set to Serial (ie, `ros_enable = False`)
:heavy_check_mark: Verified down-stroke precision within +/- 1 mm
:x: Issues with sending same or similar positions repeatedly

## High / Low Speed Effect
![hi_low_speed](https://user-images.githubusercontent.com/44533530/181607855-41d3a85d-3305-4985-90bc-7590912694d8.png)

## Known Issues
:x: If same position repeatedly sent via either Remote mode, system will oscillate due to imprecise position control.

<img src="https://user-images.githubusercontent.com/44533530/181607370-6c63078e-0bf7-447d-be58-30de61b8af11.png" width="300" /> 

