### PR TITLE
Bug Fix: Unattended Motion

### DIFF
--- a/arduino_control/control_as_client/control_as_client.ino
+++ b/arduino_control/control_as_client/control_as_client.ino
@@ -13,7 +13,7 @@
  * Author: Adam Buynak
  */
  
- /* Software Version: v0.2.0 */
+ /* Software Version: v0.2.1 */
 
 
 #include <Arduino.h>

--- a/arduino_control/control_as_client/h_controller.ino
+++ b/arduino_control/control_as_client/h_controller.ino
@@ -35,6 +35,20 @@ void controller(float current_posn) {
 
 
 
+  // ----------------------------
+  // Hydraulic Motor State Check
+  // ----------------------------
+  // Kill motion command if hydraulic pump is inactive
+  
+  if(current_press_power_switch_state == false)
+  {
+    halt();
+    set_flow_control_valve(LOW);  // default back to slow speed
+    target_posn = current_posn;   // fail safe
+  }
+
+
+
   // -----------------------------
   // Remote Input ~ Serial or ROS
   // -----------------------------
@@ -84,14 +98,6 @@ void controller(float current_posn) {
   // ---------------------------
 
   if (remoteTargetAchieved == false && remoteMotionEnabled && override_lockout == false) {
-
-    // Kill motion command if hydraulic pump is inactive
-    if(current_press_power_switch_state == false)
-    {
-      halt();
-      set_flow_control_valve(LOW);  // default back to slow speed
-      target_posn = current_posn;   // fail safe
-    }
     
     // Check if target position achieved
     if      (directionOfMotion == false && current_posn >= target_posn) remoteTargetAchieved = true;  // overshoot moving down              

--- a/arduino_control/control_as_client/h_controller.ino
+++ b/arduino_control/control_as_client/h_controller.ino
@@ -13,6 +13,7 @@ void controller(float current_posn) {
   bool mswitch_up  = P1.readDiscrete(1,1);
   bool mswitch_dwn = P1.readDiscrete(1,2);
   bool override_lockout = (last_override + override_timeout) > millis();
+  bool current_press_power_switch_state = get_press_power_switch_state();
 
   if (mswitch_up || mswitch_dwn || override_lockout) {
     set_flow_control_valve(LOW);
@@ -83,6 +84,14 @@ void controller(float current_posn) {
   // ---------------------------
 
   if (remoteTargetAchieved == false && remoteMotionEnabled && override_lockout == false) {
+
+    // Kill motion command if hydraulic pump is inactive
+    if(current_press_power_switch_state == false)
+    {
+      halt();
+      set_flow_control_valve(LOW);  // default back to slow speed
+      target_posn = current_posn;   // fail safe
+    }
     
     // Check if target position achieved
     if      (directionOfMotion == false && current_posn >= target_posn) remoteTargetAchieved = true;  // overshoot moving down              


### PR DESCRIPTION
This PR fixes the previously identified unattended motion bug. 

I fixed this by setting the target position to the current position if/when the power switch to the press is set to "OFF". The status of the power switch is checked on every loop.

Fixes #12 