### PR TITLE
Induction Coil Control as ROS Service

### DIFF
--- a/arduino_control/control_as_client/a_declarations.ino
+++ b/arduino_control/control_as_client/a_declarations.ino
@@ -23,6 +23,7 @@ void set_remote_indicator();
 
 // ROS & Network Interfaces
 void cb_joint_command(const std_msgs::Float64);
+void cb_induction_coil_command(const std_msgs::Bool);
 void update_ros_robot_status();
 void update_ros_joint_states();
 void update_ros_fork_state();
@@ -42,3 +43,4 @@ bool tempFlowValveState = false;
 // Controller
 void controller();
 void set_fork_power(bool state);
+void set_induction_power(bool state);

--- a/arduino_control/control_as_client/c_setup.ino
+++ b/arduino_control/control_as_client/c_setup.ino
@@ -25,6 +25,7 @@ ros::Publisher pub_temperature1_alarm1_state("temperature1_alarm1_state", &tempe
 ros::Publisher pub_temperature1("temperature1", &temperature1_msg);
 //ros::Publisher pub_robot_status("robot_status", &robot_status_msg);
 
+ros::Subscriber<std_msgs::Bool> sub_induction_coil_command("set_induction_coil_power", &cb_induction_coil_command);
 ros::Subscriber<std_msgs::Float64> sub_joint_command("joint_command", cb_joint_command);
 
 
@@ -61,7 +62,10 @@ void setup() {
   }
 
   // Initialize Sensors
-  set_fork_power(true);
+  set_fork_power(false);
+
+  // Ensure heater starts in OFF state
+  set_induction_power(false);
 
   // Exteneral Remote Control Indicator
   pinMode(LED_BUILTIN, OUTPUT);

--- a/arduino_control/control_as_client/control_as_client.ino
+++ b/arduino_control/control_as_client/control_as_client.ino
@@ -8,12 +8,36 @@
  * roslaunch rosserial_server socket.launch
  * The default port is 11411
  * 
- * Copyright (c) 2022, The Ohio State University
+ * Copyright (c) 2022-2023, The Ohio State University
  * The Artificially Intelligent Manufacturing Systems Lab (AIMS)
  * Author: Adam Buynak
  */
  
- /* Software Version: v0.2.2 */
+ /* Software Version: v0.2.3 */
+
+
+/* ------------------------------------------
+ * | Card | Port | Use
+ * |-----------------------------------------
+ * |  1   |  1R  | Empty
+ * |  1   |  2R  | Empty
+ * |  1   |  3R  | Temperature alarm 1
+ * |  1   |  4R  | Empty
+ * |  1   |  5R  | Fork State
+ * |  1   |  6R  | Press Power Switch State
+ * |  1   |  7R  | Empty
+ * |  1   |  8R  | Empty
+ * |-----------------------------------------
+ * |  1   |  1W  | Empty
+ * |  1   |  2W  | Empty
+ * |  1   |  3W  | Induction Heater
+ * |  1   |  4W  | Fork Sensor power
+ * |  1   |  5W  | Hydraulic Valve 1
+ * |  1   |  6W  | Hydraulic Valve 2
+ * |  1   |  7W  | Flow control valve
+ * -----------------------------------------
+ */
+
 
 
 #include <Arduino.h>

--- a/arduino_control/control_as_client/g_ros.ino
+++ b/arduino_control/control_as_client/g_ros.ino
@@ -14,10 +14,19 @@ void setup_ros() {
   nh.advertise(pub_press_power_switch_state);
   nh.advertise(pub_temperature1_alarm1_state);
   nh.advertise(pub_temperature1);
-//  nh.advertise(pub_robot_status);/
+//  nh.advertise(pub_robot_status);
 
+  nh.subscribe(sub_induction_coil_command);
   nh.subscribe(sub_joint_command);
 }
+
+
+void cb_induction_coil_command(const std_msgs::Bool &msg) {
+
+  // Set Coil Power State
+  set_induction_power(msg.data);
+}
+
 
 void cb_joint_command(const std_msgs::Float64& msg) {
   

--- a/arduino_control/control_as_client/h_controller.ino
+++ b/arduino_control/control_as_client/h_controller.ino
@@ -129,3 +129,22 @@ void controller(float current_posn) {
     else if (directionOfMotion == true) set_flow_control_valve(LOW);
   }
 }
+
+
+void set_induction_power(bool state)
+{
+  // Set power to induction heater remote switch
+  P1.writeDiscrete(state,1,3); // Turn on slot 1 channel 3
+
+  // Report state change
+  if( state )
+  {
+    Serial.println("Induction heater set to: ON");
+    nh.loginfo("Induction heater set to: ON");
+  }
+  else
+  {
+    Serial.println("Induction heater set to: OFF");
+    nh.loginfo("Induction heater set to: OFF");
+  }
+}


### PR DESCRIPTION
These changes add a new ROS topic subscriber which controls the state of the Induction Heater

## Testing
Tested with induction heater control switch wired coaliron press control panel on Slot 1, Pin 3. 
When the pin is set HIGH, the timer starts and the coil powers on.

## Version Note
This will release a new patch semver version.